### PR TITLE
Improve comparison of warn and crit levels

### DIFF
--- a/share/check_mk/checks/rabbitmq_queues
+++ b/share/check_mk/checks/rabbitmq_queues
@@ -47,10 +47,10 @@ def check_rabbitmq_queues(item, params, info):
 
       label=""
 
-      if ccrit and consumerCount <= ccrit:
+      if ccrit is not None and consumerCount <= ccrit:
         state = 2
         label = "(!!)"
-      elif cwarn and consumerCount <= cwarn:
+      elif cwarn is not None and consumerCount <= cwarn:
         state = max(state,1)
         label = "(!)"
       if state > 0:
@@ -60,10 +60,10 @@ def check_rabbitmq_queues(item, params, info):
       perf.append(("consumers", consumerCount, warn, crit))
       label = ""
 
-      if crit and size >= crit:
+      if crit is not None and size >= crit:
         state = 2
         label = "(!!)"
-      elif warn and size >= warn:
+      elif warn is not None and size >= warn:
         state=max(state,1)
         label = "(!)"
       msg += "Queue Size: %s " % size


### PR DESCRIPTION
Currently it is not possible (for example) to set the check to "CRIT" when there is no consumer subscribed to a queue.
When defining "0" as crit or warn value the comparison returns "False" and does not set the state correctly. 
As far as I can tell from my testing "is not None" works fine here.